### PR TITLE
feat: devcontainer now using ssh keys from host machine

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,10 @@
     "name": "PHP Development Container",
     "dockerComposeFile": "../docker-compose.yml",
     "service": "php",
-    "workspaceFolder": "/var/www"
+    "workspaceFolder": "/var/www",
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {
+            "enableGitCredentialHelper": true
+        }
+    }
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `.devcontainer/devcontainer.json` file. The change adds a new feature to the development container configuration to enable the Git credential helper.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L5-R10): Added the `ghcr.io/devcontainers/features/git:1` feature with the `enableGitCredentialHelper` option set to true.