### PR TITLE
fix: add assets building in tests workflow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts"
+          node-version: "stable"
       - name: Install NPM Dependencies
         run: npm install
       - name: Build Frontend Assets

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -29,8 +29,6 @@ jobs:
           touch database/database.sqlite
       - name: Install Node.js
         uses: actions/setup-node@v3
-        with:
-          node-version: "stable"
       - name: Install NPM Dependencies
         run: npm install
       - name: Build Frontend Assets

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -2,34 +2,41 @@ name: Laravel
 
 on:
   push:
-    branches: [ "*" ]
+    branches: ["*"]
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
 
 jobs:
   laravel-tests:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
-    - uses: actions/checkout@v3
-    - name: Copy .env
-      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
-    - name: Install Dependencies
-      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --ignore-platform-reqs
-    - name: Generate key
-      run: php artisan key:generate
-    - name: Directory Permissions
-      run: chmod -R 777 storage bootstrap/cache
-    - name: Create Database
-      run: |
-        mkdir -p database
-        touch database/database.sqlite
-    - name: Execute tests (Unit and Feature tests) via PHPUnit
-      env:
-        DB_CONNECTION: sqlite
-        DB_DATABASE: database/database.sqlite
-      run: vendor/bin/phpunit
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+      - uses: actions/checkout@v3
+      - name: Copy .env
+        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+      - name: Install PHP Dependencies
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --ignore-platform-reqs
+      - name: Generate key
+        run: php artisan key:generate
+      - name: Directory Permissions
+        run: chmod -R 777 storage bootstrap/cache
+      - name: Create Database
+        run: |
+          mkdir -p database
+          touch database/database.sqlite
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts"
+      - name: Install NPM Dependencies
+        run: npm install
+      - name: Build Frontend Assets
+        run: npm run build
+      - name: Execute tests (Unit and Feature tests) via PHPUnit
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: database/database.sqlite
+        run: vendor/bin/phpunit


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for Laravel to enhance the setup and testing process. The most important changes include renaming a job step, adding steps to install Node.js and NPM dependencies, and building frontend assets.

Enhancements to the workflow:

* [`.github/workflows/laravel.yml`](diffhunk://#diff-780598065d009a102c43b543e7f6670ce1d9029b6ddb86dc98cb1a94433cccb1L11-R20): Renamed the job step from "Install Dependencies" to "Install PHP Dependencies" for clarity.
* [`.github/workflows/laravel.yml`](diffhunk://#diff-780598065d009a102c43b543e7f6670ce1d9029b6ddb86dc98cb1a94433cccb1R30-R35): Added steps to install Node.js, install NPM dependencies, and build frontend assets to ensure the frontend is properly set up before running tests.