### PR TITLE
fix(models): correct relationship reference in WorkOrderBlockTask for task type

### DIFF
--- a/app/Models/WorkOrderBlockTask.php
+++ b/app/Models/WorkOrderBlockTask.php
@@ -27,7 +27,7 @@ class WorkOrderBlockTask extends Model
 
     public function tasksTypes()
     {
-        return $this->belongsTo(Task::class, 'task_type_id');
+        return $this->belongsTo(TaskType::class, 'task_type_id');
     }
 
     public function workOrderBlocks()


### PR DESCRIPTION
This pull request includes a small but important change to the `app/Models/WorkOrderBlockTask.php` file. The change ensures that the `tasksTypes` method returns the correct relationship.

* [`app/Models/WorkOrderBlockTask.php`](diffhunk://#diff-4f444250a6dac5ffb10e5a34f9e6357cc80afaca2147ec47a291f6f6637884f3L30-R30): Modified the `tasksTypes` method to return a `belongsTo` relationship with the `TaskType` class instead of the `Task` class.