### PR TITLE
refactor: restore CSRF token validation for API middleware

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,9 +15,6 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->validateCsrfTokens(except: [
-            'api/*',
-        ]);
         $middleware->statefulApi();
         $middleware->append(LanguageMiddleware::class);
     })


### PR DESCRIPTION
This pull request includes a change to the `bootstrap/app.php` file to simplify the middleware configuration by removing the CSRF token validation exclusion for API routes.

Simplification of middleware configuration:

* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518L18-L20): Removed the CSRF token validation exclusion for API routes to streamline the middleware setup.