### PR TITLE
refactor: sync sites langs

### DIFF
--- a/app/Http/Controllers/LangController.php
+++ b/app/Http/Controllers/LangController.php
@@ -10,7 +10,7 @@ class LangController extends Controller
     public function setLanguage($lang)
     {
         App::setLocale($lang);
-        Cookie::queue('locale', $lang, 60 * 24 * 30);
+        Cookie::queue(Cookie::make('lang', $lang, 525600, '/', null, false, false));
 
         return redirect()->back();
     }

--- a/app/Http/Middleware/LanguageMiddleware.php
+++ b/app/Http/Middleware/LanguageMiddleware.php
@@ -16,8 +16,8 @@ class LanguageMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (Cookie::has('locale')) {
-            app()->setLocale(Cookie::get('locale'));
+        if (Cookie::has('lang')) {
+            app()->setLocale(Cookie::get('lang'));
         } else {
             app()->setLocale('ca');
         }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        EncryptCookies::except('locale');
+        EncryptCookies::except('lang');
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "react-i18next": "^15.4.0",
                 "react-router-dom": "^7.1.5",
                 "tailwindcss": "^4.0.3",
-                "typescript": "^5.7.3"
+                "typescript": "^5.7.3",
+                "typescript-cookie": "^1.0.6"
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.26.7",
@@ -8135,6 +8136,14 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-cookie": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/typescript-cookie/-/typescript-cookie-1.0.6.tgz",
+            "integrity": "sha512-s+BZr7/9BUG6Kg7jGGcOY/4XJcP+iZRFdF3q4FPTfRSP83ivLWF94OcH8PrzGmnS8Ab9qP7ENu/ikLwNFsIafA==",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "react-i18next": "^15.4.0",
         "react-router-dom": "^7.1.5",
         "tailwindcss": "^4.0.3",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "typescript-cookie": "^1.0.6"
     }
 }

--- a/resources/ts/config/i18n.ts
+++ b/resources/ts/config/i18n.ts
@@ -4,6 +4,8 @@ import ca from './i18n/ca.json';
 import es from './i18n/es.json';
 import en from './i18n/en.json';
 
+import { getCookie, setCookie } from 'typescript-cookie';
+
 const resources = {
   ca: {
     translation: ca,
@@ -16,15 +18,15 @@ const resources = {
   },
 };
 
-if (localStorage.getItem('lang') === null) {
-  localStorage.setItem('lang', 'ca');
+if(!getCookie('lang')) {
+  setCookie('lang', 'ca');
 }
 
-const localStorageLang = localStorage.getItem('lang') || 'ca';
+const lang = getCookie('lang');
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: localStorageLang,
+  lng: lang,
   interpolation: {
     escapeValue: true,
   },

--- a/resources/ts/hooks/useI18n.ts
+++ b/resources/ts/hooks/useI18n.ts
@@ -1,10 +1,11 @@
 import { useTranslation } from 'react-i18next';
+import { setCookie } from 'typescript-cookie';
 
 export function useI18n() {
   const { t, i18n } = useTranslation();
 
   const setLanguage = (lang: string) => {
-    localStorage.setItem('lang', lang);
+    setCookie('lang', lang);
     i18n.changeLanguage(lang);
   };
 


### PR DESCRIPTION
This pull request includes several changes aimed at transitioning the language preference storage from `localStorage` to cookies, and updating dependencies accordingly. The most important changes include modifications to the `LangController`, `LanguageMiddleware`, and `AppServiceProvider` classes, as well as updates to the `i18n` configuration and the addition of a new dependency in `package.json`.

### Transition from `localStorage` to cookies for language preference:

* [`app/Http/Controllers/LangController.php`](diffhunk://#diff-a47e65e974ad99e452777cc9a034d22d331bc2a380516b18f9edff7a3a2338c8L13-R13): Updated the `setLanguage` method to use `Cookie::make` for setting the language cookie instead of `Cookie::queue`.
* [`app/Http/Middleware/LanguageMiddleware.php`](diffhunk://#diff-4dd3808bc5cecc4f539225f83f28ed3321dca981629ca21c7f31b6e26daa9118L19-R20): Modified the `handle` method to check for the `lang` cookie instead of `locale`.
* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL23-R23): Updated the `EncryptCookies` exception to use `lang` instead of `locale`.

### Updates to `i18n` configuration:

* [`resources/ts/config/i18n.ts`](diffhunk://#diff-765a198fd5d323ba6d1200240ae5faadb44fd80c2eda05d30f881be581f13759R7-R8): Replaced `localStorage` usage with `typescript-cookie` for getting and setting the language preference. [[1]](diffhunk://#diff-765a198fd5d323ba6d1200240ae5faadb44fd80c2eda05d30f881be581f13759R7-R8) [[2]](diffhunk://#diff-765a198fd5d323ba6d1200240ae5faadb44fd80c2eda05d30f881be581f13759L19-R29)
* [`resources/ts/hooks/useI18n.ts`](diffhunk://#diff-86d1fda22ca4d184b123b9fd3cbe891ecc4c04e1fca6f9b4299f0abb0d9c62e1R2-R8): Updated the `setLanguage` function to use `setCookie` instead of `localStorage`.

### Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-R42): Added `typescript-cookie` as a new dependency.