### PR TITLE
refactor: adjust background color opacity for #app

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,7 +9,7 @@ body {
 
 #app {
   min-height: 100vh;
-  background-color: rgba(249, 250, 251, 0.9);
+  background-color: rgba(249, 250, 251, 0.85);
 }
 
 /* Fade animation */


### PR DESCRIPTION
This pull request includes a small change to the `resources/css/app.css` file. The change adjusts the background color opacity of the `#app` element from 0.9 to 0.85.