### PR TITLE
refactor: make landing routes dynamic and update form handling

### DIFF
--- a/app/Http/Controllers/LandingController.php
+++ b/app/Http/Controllers/LandingController.php
@@ -7,27 +7,36 @@ use Illuminate\Http\Request;
 
 class LandingController extends Controller
 {
-    public function index()
+    public function index(int $number)
     {
-        return view('/Landings/landing11');
+        return view("/Landings/landing$number");
     }
 
-    public function store(Request $request)
+    public function store(int $number, Request $request)
     {
-        $request->validate([
-            'name' => 'required|string|max:150',
-            'email' => 'required|email|max:255',
-            'phone' => 'nullable|regex:/^(?=(?:\D*\d){9}\D*$)[0-9\s]+$/',
-            'message' => 'required|string|min:10|max:255',
-        ]);
+        switch ($number) {
+            case 11:
+                $request->validate([
+                    'name' => 'required|string|max:150',
+                    'email' => 'required|email|max:255',
+                    'phone' => 'nullable|regex:/^(?=(?:\D*\d){9}\D*$)[0-9\s]+$/',
+                    'message' => 'required|string|min:10|max:255',
+                ]);
 
-        $landingForm = new LandingForm;
-        $landingForm->name = $request->name;
-        $landingForm->email = $request->email;
-        $landingForm->phone = $request->phone;
-        $landingForm->message = $request->message;
-        $landingForm->save();
+                $landingForm = new LandingForm;
+                $landingForm->name = $request->name;
+                $landingForm->email = $request->email;
+                $landingForm->phone = $request->phone;
+                $landingForm->message = $request->message;
+                $landingForm->save();
 
-        return redirect('/landing11')->with('success', 'Mensaje enviado correctamente.');
+                break;
+
+            default:
+                # code...
+                break;
+        }
+
+        return redirect("/landing$number")->with('success', 'Mensaje enviado correctamente.');
     }
 }

--- a/resources/views/Landings/landing11.blade.php
+++ b/resources/views/Landings/landing11.blade.php
@@ -224,7 +224,7 @@
         </ul>
       </div>
       @endif
-      <form id="contact" action="{{ route('landing.form') }}" method="POST" class="space-y-6">
+      <form id="contact" action="{{ route('landing.form', ['number' => 11]) }}" method="POST" class="space-y-6">
         @csrf
         <div>
           <label class="block text-gray-700 font-semibold mb-2">{{ __('landings/landing11.name') }}</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,9 +4,9 @@ use App\Http\Controllers\LandingController;
 use App\Http\Controllers\LangController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/landing11', [LandingController::class, 'index'])->name('landing');
+Route::get('/landing{number}', [LandingController::class, 'index'])->where('number', '[0-9]+')->name('landing');
 
-Route::post('/landing11/landing11-form', [LandingController::class, 'store'])->name('landing.form');
+Route::post('/landing{number}/form', [LandingController::class, 'store'])->name('landing.form');
 
 Route::get('/set-language/{lang}', [LangController::class, 'setLanguage'])->name('set-language');
 


### PR DESCRIPTION
This pull request includes changes to the `LandingController` and related routes and views to support dynamic landing page numbers. The most important changes include modifying the controller methods to accept a `number` parameter, updating the routes to use dynamic segments, and adjusting the form action in the view.

Changes to `LandingController`:

* [`app/Http/Controllers/LandingController.php`](diffhunk://#diff-3eaa8a20c34668a2a5c7fa5e355631ec940d9841311359def89a413b3212c31eL10-R18): Modified the `index` and `store` methods to accept an `int $number` parameter and updated the view and redirect paths to use this dynamic number. [[1]](diffhunk://#diff-3eaa8a20c34668a2a5c7fa5e355631ec940d9841311359def89a413b3212c31eL10-R18) [[2]](diffhunk://#diff-3eaa8a20c34668a2a5c7fa5e355631ec940d9841311359def89a413b3212c31eL31-R40)

Updates to routes:

* [`routes/web.php`](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL7-R9): Updated the routes to use a dynamic segment `{number}` for the landing pages and their forms, ensuring the `number` parameter is a digit.

Changes to views:

* [`resources/views/Landings/landing11.blade.php`](diffhunk://#diff-6835bc0c94927026e05ebef75dff21beec25ced61453ba36fca7413cad0b2bf1L227-R227): Adjusted the form action to include the `number` parameter in the route.