### PR TITLE
fix: update video URL for Urban Tree introduction on landing 9 (catalan)

### DIFF
--- a/lang/ca/landings/landing9.php
+++ b/lang/ca/landings/landing9.php
@@ -57,7 +57,7 @@ return [
     'cta' => [
         'title' => 'Uneix-te a la comunitat Urban Tree',
         'description' => 'Descobreix com pots contribuir al futur de la gestió sostenible de l\'arbrat urbà. Visita el nostre repositori i comença a col·laborar.',
-        'video_url' => 'https://www.youtube.com/embed/M0VBcCEp10E',
+        'video_url' => 'https://www.youtube.com/embed/3eCPW5mGKhw',
         'video_title' => 'Introducció a Urban Tree 5.0',
     ],
     'footer' => [


### PR DESCRIPTION
This pull request includes a small change to the `lang/ca/landings/landing9.php` file. The change updates the `video_url` in the call-to-action section.

* [`lang/ca/landings/landing9.php`](diffhunk://#diff-6764d62127c474c2109938ca4db5445b20365754fad1146a4b587763c8b43462L60-R60): Updated the `video_url` from 'https://www.youtube.com/embed/M0VBcCEp10E' to 'https://www.youtube.com/embed/3eCPW5mGKhw'.