### PR TITLE
feat(i18n): add translation for "eva" in Catalan, English, and Spanish

### DIFF
--- a/resources/ts/config/i18n/ca.json
+++ b/resources/ts/config/i18n/ca.json
@@ -487,6 +487,7 @@
         "resources": "Recursos",
         "stats": "Estadístiques",
         "workers": "Treballadors",
+        "eva": "EVA",
         "workOrders": "Ordres de treball"
       },
       "settings": {

--- a/resources/ts/config/i18n/en.json
+++ b/resources/ts/config/i18n/en.json
@@ -487,6 +487,7 @@
         "resources": "Resources",
         "stats": "Statistics",
         "workers": "Workers",
+        "eva": "EVA",
         "workOrders": "Work Orders"
       },
       "settings": {

--- a/resources/ts/config/i18n/es.json
+++ b/resources/ts/config/i18n/es.json
@@ -487,6 +487,7 @@
         "resources": "Recursos",
         "stats": "Estadísticas",
         "workers": "Trabajadores",
+        "eva": "EVA",
         "workOrders": "Órdenes de trabajo"
       },
       "settings": {


### PR DESCRIPTION
This pull request includes updates to the internationalization (i18n) configuration files to add a new translation entry for "EVA" across multiple languages.

Updates to i18n configuration:

* [`resources/ts/config/i18n/ca.json`](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85R490): Added the translation entry for "EVA" in Catalan.
* [`resources/ts/config/i18n/en.json`](diffhunk://#diff-75fa9e3a78347c6cd6a747ef879348f248881628a32d8926eba7a5036998bba3R490): Added the translation entry for "EVA" in English.
* [`resources/ts/config/i18n/es.json`](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6R490): Added the translation entry for "EVA" in Spanish.