### PR TITLE
feat(contracts): refactor status display logic in Contracts component

### DIFF
--- a/resources/ts/pages/Admin/Settings/Contracts/Contracts.tsx
+++ b/resources/ts/pages/Admin/Settings/Contracts/Contracts.tsx
@@ -31,12 +31,6 @@ export default function Contracts() {
     const errorMsg = location.state?.error;
     const [msg, setMsg] = useState<string | null>(successMsg || errorMsg || null);
 
-    const statusOptions = [
-        { label: t("admin.status.active"), value: 0, color: "yellow" },
-        { label: t("admin.status.inactive"), value: 1, color: "red" },
-        { label: t("admin.status.completed"), value: 2, color: "green" }
-    ];
-
     useEffect(() => {
         const fetchContracts = async () => {
             try {
@@ -103,12 +97,18 @@ export default function Contracts() {
                     <Column field="start_date" header={t("admin.pages.contracts.list.columns.start_date")} />
                     <Column field="end_date" header={t("admin.pages.contracts.list.columns.end_date")} />
                     <Column field="final_price" header={t("admin.pages.contracts.list.columns.final_price")} />
-                    <Column field="status" header={t("admin.pages.contracts.list.columns.status")} body={(rowData: Contract) => (
-                        <Badge
-                            value={statusOptions.find(option => option.value === rowData.status)?.label}
-                            style={{ backgroundColor: statusOptions.find(option => option.value === rowData.status)?.color }}
-                        />
-                    )} />
+                    <Column field="status" header={t("admin.pages.contracts.list.columns.status")} body={(rowData: Contract) => {
+                        switch (rowData.status) {
+                            case 0:
+                                return <Badge value={t("admin.status.active")} severity="warning" />
+                            case 1:
+                                return <Badge value={t("admin.status.inactive")} severity="danger" />
+                            case 2:
+                                return <Badge value={t("admin.status.completed")} severity="success" />
+                            default:
+                                return <Badge value={t("admin.status.unknown")} severity="secondary" />
+                        }
+                    }} />
                     <Column
                         header={t("admin.pages.contracts.list.actions.label")}
                         body={(rowData: { id: number }) => (


### PR DESCRIPTION
This pull request includes changes to the `Contracts` component in the `resources/ts/pages/Admin/Settings/Contracts/Contracts.tsx` file. The main focus is on refactoring how contract status is handled and displayed.

Refactoring contract status handling:

* Removed the `statusOptions` array and replaced it with a `switch` statement to handle different contract statuses directly in the JSX. This change simplifies the code and improves readability.
* Updated the `Column` component for the `status` field to use the new `switch` statement, ensuring that the correct badge with the appropriate label and severity is displayed based on the contract status.