### PR TITLE
feat(ci): update SSH port in production deployment workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -50,4 +50,4 @@ jobs:
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
-          rsync -avz --delete --exclude=".devcontainer" --exclude=".docker" --exclude=".github" --exclude=".vscode" --exclude="tests" -e 'ssh -i private_key.pem -o StrictHostKeyChecking=no' ./ $SSH_USER@$SSH_HOST:$REMOTE_PATH
+          rsync -avz --delete --exclude=".devcontainer" --exclude=".docker" --exclude=".github" --exclude=".vscode" --exclude="tests" -e 'ssh -i private_key.pem -p 21222 -o StrictHostKeyChecking=no' ./ $SSH_USER@$SSH_HOST:$REMOTE_PATH


### PR DESCRIPTION
This pull request includes a single change to the deployment process in the `deploy-production.yml` workflow file. The change modifies the SSH command to use a specific port for the connection.

* [`.github/workflows/deploy-production.yml`](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94L53-R53): Updated the `rsync` command to use port `21222` for SSH connections.