### PR TITLE
feat: update workflow permissions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,6 +51,8 @@ jobs:
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
           REMOTE_PATH: ${{ secrets.REMOTE_PATH }}
         run: |
+          sudo apt-get update && sudo apt-get install -y sshpass
           sshpass -p "$SSH_PASSWORD" rsync -avz --delete \
             --exclude=".devcontainer" --exclude=".docker" --exclude=".github" --exclude=".vscode" --exclude="tests" \
+            --no-perms --no-group --chmod=ugo=rwX \
             -e 'ssh -p 21222 -o StrictHostKeyChecking=no' ./ $SSH_USER@$SSH_HOST:$REMOTE_PATH


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy-production.yml` file. The change adds a command to update the package list and install `sshpass`, and modifies the `rsync` command to include additional options for permissions and group handling.

Changes in deployment workflow:

* [`.github/workflows/deploy-production.yml`](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94R54-R57): Added `sudo apt-get update && sudo apt-get install -y sshpass` to the `run` section to ensure `sshpass` is installed.
* [`.github/workflows/deploy-production.yml`](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94R54-R57): Modified the `rsync` command to include `--no-perms`, `--no-group`, and `--chmod=ugo=rwX` options for better permission and group handling.