### PR TITLE
chore: exclude additional files from production deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -54,5 +54,6 @@ jobs:
           sudo apt-get update && sudo apt-get install -y sshpass
           sshpass -p "$SSH_PASSWORD" rsync -avz --delete \
             --exclude=".devcontainer" --exclude=".docker" --exclude=".github" --exclude=".vscode" --exclude="tests" \
+            --exclude=".env" --exclude="database/database.sqlite" \
             --no-perms --no-group --chmod=ugo=rwX \
             -e 'ssh -p 21222 -o StrictHostKeyChecking=no' ./ $SSH_USER@$SSH_HOST:$REMOTE_PATH


### PR DESCRIPTION
This pull request includes a small but important change to the `deploy-production` workflow. The change ensures that sensitive and unnecessary files are excluded during the deployment process.

* [`.github/workflows/deploy-production.yml`](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94R57): Added `.env` and `database/database.sqlite` to the list of excluded files during the rsync operation to prevent sensitive data from being transferred.