### PR TITLE
feat: enhance statistics page with custom date range selection using …

### DIFF
--- a/resources/ts/pages/Admin/Statistics.tsx
+++ b/resources/ts/pages/Admin/Statistics.tsx
@@ -2,6 +2,8 @@ import axiosClient from '@/api/axiosClient';
 import { differenceInMonths, parseISO } from 'date-fns';
 import { Chart } from 'primereact/chart';
 import { Skeleton } from 'primereact/skeleton';
+import { SelectButton } from 'primereact/selectbutton';
+import { Calendar } from 'primereact/calendar';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -65,6 +67,14 @@ export default function Stats() {
   const [isLoading, setIsLoading] = useState(false);
   const [customFromIso, setCustomFromIso] = useState('');
   const [customToIso, setCustomToIso] = useState('');
+  const [customFromDate, setCustomFromDate] = useState<Date | null>(null);
+  const [customToDate, setCustomToDate] = useState<Date | null>(null);
+
+  const rangeOptions = [
+    { label: t('admin.pages.stats.week'), value: 'this_week' },
+    { label: t('admin.pages.stats.month'), value: 'this_month' },
+    { label: t('admin.pages.stats.custom'), value: 'custom' }
+  ];
 
   useEffect(() => {
     if (rangeOption === 'this_week') {
@@ -94,19 +104,23 @@ export default function Stats() {
   }, [fromDate, toDate]);
 
   useEffect(() => {
-    if (rangeOption === 'custom' && customFromIso && customToIso) {
-      const startDate = parseISO(customFromIso);
-      const endDate = parseISO(customToIso);
-      const totalMonths = differenceInMonths(endDate, startDate);
+    if (rangeOption === 'custom' && customFromDate && customToDate) {
+      const fromIso = customFromDate.toISOString().split('T')[0];
+      const toIso = customToDate.toISOString().split('T')[0];
+      
+      setCustomFromIso(fromIso);
+      setCustomToIso(toIso);
+      setFromDate(parseIsoToSpanish(fromIso));
+      setToDate(parseIsoToSpanish(toIso));
+      
+      const totalMonths = differenceInMonths(customToDate, customFromDate);
       if (totalMonths > 12) {
-        const maxEndDate = new Date(startDate);
+        const maxEndDate = new Date(customFromDate);
         maxEndDate.setFullYear(maxEndDate.getFullYear() + 1);
-        const adjustedToIso = maxEndDate.toISOString().split('T')[0];
-        setCustomToIso(adjustedToIso);
-        setToDate(parseIsoToSpanish(adjustedToIso));
+        setCustomToDate(maxEndDate);
       }
     }
-  }, [customFromIso, customToIso, rangeOption]);
+  }, [customFromDate, customToDate, rangeOption]);
 
   const fetchData = async () => {
     setIsLoading(true);
@@ -171,93 +185,41 @@ export default function Stats() {
     },
   ];
 
-  const maxAllowedToDate = customFromIso
-    ? new Date(
-        new Date(customFromIso).setFullYear(
-          new Date(customFromIso).getFullYear() + 1,
-        ),
-      )
-        .toISOString()
-        .split('T')[0]
-    : new Date().toISOString().split('T')[0];
+  const maxDate = customFromDate ? new Date(customFromDate.getFullYear() + 1, customFromDate.getMonth(), customFromDate.getDate()) : new Date();
 
   return (
     <div className="flex flex-col gap-4 p-4">
-      <div className="flex flex-wrap items-center gap-4">
-        <div className="flex items-center gap-2">
-          <input
-            type="radio"
-            id="this_week"
-            name="rangeOption"
-            value="this_week"
-            checked={rangeOption === 'this_week'}
-            onChange={() => setRangeOption('this_week')}
+      <div className="flex flex-wrap items-end gap-4">
+        <div>
+          <SelectButton 
+            value={rangeOption} 
+            options={rangeOptions} 
+            onChange={(e) => setRangeOption(e.value)} 
           />
-          <label htmlFor="this_week" className="cursor-pointer">
-            {t('admin.pages.stats.week')}
-          </label>
         </div>
-        <div className="flex items-center gap-2">
-          <input
-            type="radio"
-            id="this_month"
-            name="rangeOption"
-            value="this_month"
-            checked={rangeOption === 'this_month'}
-            onChange={() => setRangeOption('this_month')}
-          />
-          <label htmlFor="this_month" className="cursor-pointer">
-            {t('admin.pages.stats.month')}
-          </label>
-        </div>
-        <div className="flex items-center gap-2">
-          <input
-            type="radio"
-            id="custom"
-            name="rangeOption"
-            value="custom"
-            checked={rangeOption === 'custom'}
-            onChange={() => setRangeOption('custom')}
-          />
-          <label htmlFor="custom" className="cursor-pointer">
-            {t('admin.pages.stats.custom')}
-          </label>
-        </div>
+        
         {rangeOption === 'custom' && (
           <>
             <div className="flex flex-col">
-              <label>{t('admin.pages.stats.startDate')}</label>
-              <input
-                type="date"
-                className="border rounded px-2 py-1"
-                value={customFromIso}
-                max={new Date().toISOString().split('T')[0]}
-                onChange={(e) => {
-                  setCustomFromIso(e.target.value);
-                  if (e.target.value) {
-                    setFromDate(parseIsoToSpanish(e.target.value));
-                  } else {
-                    setFromDate('');
-                  }
-                }}
+              <label className="mb-2">{t('admin.pages.stats.startDate')}</label>
+              <Calendar 
+                value={customFromDate}
+                onChange={(e) => setCustomFromDate(e.value as Date)}
+                maxDate={new Date()}
+                showIcon
+                dateFormat="dd/mm/yy"
               />
             </div>
             <div className="flex flex-col">
-              <label>{t('admin.pages.stats.endDate')}</label>
-              <input
-                type="date"
-                className="border rounded px-2 py-1"
-                value={customToIso}
-                min={customFromIso || undefined}
-                max={maxAllowedToDate}
-                onChange={(e) => {
-                  setCustomToIso(e.target.value);
-                  if (e.target.value) {
-                    setToDate(parseIsoToSpanish(e.target.value));
-                  } else {
-                    setToDate('');
-                  }
-                }}
+              <label className="mb-2">{t('admin.pages.stats.endDate')}</label>
+              <Calendar 
+                value={customToDate}
+                onChange={(e) => setCustomToDate(e.value as Date)}
+                minDate={customFromDate || undefined}
+                maxDate={maxDate}
+                showIcon
+                dateFormat="dd/mm/yy"
+                disabled={!customFromDate}
               />
             </div>
           </>


### PR DESCRIPTION
This pull request enhances the `Stats` component in the `resources/ts/pages/Admin/Statistics.tsx` file by improving the date range selection functionality. The main changes include replacing the radio buttons with a `SelectButton` for range options, switching from ISO date strings to `Date` objects for custom date ranges, and using the `Calendar` component for date selection.

Improvements to date range selection:

* Added imports for `SelectButton` and `Calendar` from `primereact` to support new UI components for date range selection.
* Introduced `customFromDate` and `customToDate` state variables to store `Date` objects instead of ISO date strings, and added `rangeOptions` array for the `SelectButton` component.
* Updated the `useEffect` hook to handle `Date` objects for custom date ranges, converting them to ISO strings when necessary and adjusting the logic for setting the maximum end date.
* Simplified the calculation of `maxDate` for the custom date range, replacing the previous logic that used ISO date strings.
* Replaced radio buttons with a `SelectButton` for range option selection and switched to `Calendar` components for custom date input, improving the user interface and experience.…calendar