### PR TITLE
feat: add contract_id to User model and migration, update UserSeeder

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable
         'dni',
         'role',
         'password',
+        'contract_id',
     ];
 
     /**
@@ -53,5 +54,10 @@ class User extends Authenticatable
     public function workOrderUsers()
     {
         return $this->hasMany(WorkOrderUser::class, 'user_id');
+    }
+
+    public function contract()
+    {
+        return $this->belongsTo(Contract::class, 'contract_id');
     }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -21,6 +21,7 @@ return new class extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->string('role')->default('customer');
+            $table->foreignId('contract_id')->nullable()->constrained('contracts')->onDelete('cascade');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -22,6 +22,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678A',
                 'password' => Hash::make('demopass'),
                 'role' => 'admin',
+                'contract_id' => null,
             ],
             [
                 'name' => 'Worker',
@@ -31,6 +32,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678B',
                 'password' => Hash::make('demopass'),
                 'role' => 'worker',
+                'contract_id' => null,
             ],
             [
                 'name' => 'Worker',
@@ -40,6 +42,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678C',
                 'password' => Hash::make('demopass'),
                 'role' => 'worker',
+                'contract_id' => null,
             ],
             [
                 'name' => 'Customer',
@@ -49,6 +52,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678D',
                 'password' => Hash::make('demopass'),
                 'role' => 'customer',
+                'contract_id' => null,
             ],
             [
                 'name' => 'Victor',
@@ -58,6 +62,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678E',
                 'password' => Hash::make('demopass'),
                 'role' => 'worker',
+                'contract_id' => null,
             ],
         ]);
     }


### PR DESCRIPTION
This pull request introduces changes to the `User` model, database migrations, and seeders to incorporate a new relationship with the `Contract` model. The most important changes include adding a new `contract_id` field to the `users` table and updating the `User` model to define this relationship.

Changes to the `User` model:

* Added the `contract_id` field to the `$fillable` array in the `User` model (`app/Models/User.php`).
* Added a new `contract` method to define the relationship between `User` and `Contract` models (`app/Models/User.php`).

Changes to database migrations:

* Added a `contract_id` foreign key to the `users` table in the `create_users_table` migration (`database/migrations/0001_01_01_000000_create_users_table.php`).

Changes to database seeders:

* Updated the `UserSeeder` to include the `contract_id` field with a default value of `null` for all seeded users (`database/seeders/UserSeeder.php`). [[1]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0R25) [[2]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0R35) [[3]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0R45) [[4]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0R55) [[5]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0R65)