### PR TITLE
feat: add contract filtering to work orders and update related components

### DIFF
--- a/app/Http/Controllers/Api/Admin/WorkOrderController.php
+++ b/app/Http/Controllers/Api/Admin/WorkOrderController.php
@@ -35,10 +35,19 @@ class WorkOrderController extends Controller
 
     public function create(Request $request)
     {
+        $contract_id = $request->query('contract_id');
+        
+        $users = User::where('role', 'worker');
+        $zones = Zone::select('id', 'name');
+        if ($contract_id) {
+            $users->where('contract_id', $contract_id);
+            $zones->where('contract_id', $contract_id);
+        }
+        
         return response()->json([
             'task_types' => TaskType::all(),
-            'users' => User::where('role', 'worker')->get(),
-            'zones' => Zone::all(),
+            'users' => $users->get(),
+            'zones' => $zones->get(),
             'tree_types' => TreeType::all(),
             'element_types' => ElementType::all(),
             'contracts' => Contract::all(),
@@ -143,7 +152,6 @@ class WorkOrderController extends Controller
             $validated = $request->validate([
                 'date' => 'required|date',
                 'users' => 'required|array',
-                'contract_id' => 'required|exists:contracts,id',
                 'blocks' => 'required|array',
                 'blocks.*.notes' => 'nullable|string',
                 'blocks.*.zones' => 'required|array',
@@ -158,7 +166,6 @@ class WorkOrderController extends Controller
             $workOrder = WorkOrder::findOrFail($id);
             $workOrder->update([
                 'date' => $validated['date'],
-                'contract_id' => $validated['contract_id'],
             ]);
 
             $workOrder->users()->sync($validated['users']);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,11 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            ContractSeeder::class,
             UserSeeder::class,
             TreeTypesSeeder::class,
             TaskTypesSeeder::class,
             ElementTypesSeeder::class,
-            ContractSeeder::class,
             ZoneSeeder::class,
             PointSeeder::class,
             ElementSeeder::class,

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -32,7 +32,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678B',
                 'password' => Hash::make('demopass'),
                 'role' => 'worker',
-                'contract_id' => null,
+                'contract_id' => 1,
             ],
             [
                 'name' => 'Worker',
@@ -42,7 +42,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678C',
                 'password' => Hash::make('demopass'),
                 'role' => 'worker',
-                'contract_id' => null,
+                'contract_id' => 2,
             ],
             [
                 'name' => 'Customer',
@@ -62,7 +62,7 @@ class UserSeeder extends Seeder
                 'dni' => '12345678E',
                 'password' => Hash::make('demopass'),
                 'role' => 'worker',
-                'contract_id' => null,
+                'contract_id' => 1,
             ],
         ]);
     }

--- a/resources/ts/layouts/AdminLayout.tsx
+++ b/resources/ts/layouts/AdminLayout.tsx
@@ -106,6 +106,10 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({
   ].some((path) => location.pathname.startsWith(path));
 
   const isSettingsPage = location.pathname.includes('/admin/settings');
+  const isWorkOrderEditPage = location.pathname.includes('/admin/work-orders/edit/');
+  const isResourceEditPage = location.pathname.includes('/admin/resources/edit/');
+
+  const hideContractSelector = isSettingsPage || isWorkOrderEditPage || isResourceEditPage;
 
   const managementSubmenuItems = [
     {
@@ -233,7 +237,7 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({
           </div>
           <div className="flex items-center gap-4">
             <div className="hidden lg:flex gap-4">
-              {!isSettingsPage && (
+              {!hideContractSelector && (
                 <>
                   <Dropdown
                     id="contractBtn"
@@ -299,7 +303,7 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({
             </Link>
           ))}
           <div className="mt-4 flex flex-col gap-4">
-            {!isSettingsPage && (
+            {!hideContractSelector && (
               <Dropdown
                 id="contractBtn"
                 name="contractBtn"

--- a/resources/ts/pages/Admin/WorkOrders/Create.tsx
+++ b/resources/ts/pages/Admin/WorkOrders/Create.tsx
@@ -30,7 +30,7 @@ const CreateWorkOrder = () => {
   const currentContract = useSelector((state: RootState) => state.contract.currentContract)
 
   useEffect(() => {
-    axiosClient.get("/admin/work-orders/create")
+    axiosClient.get(`/admin/work-orders/create${currentContract ? `?contract_id=${currentContract.id}` : ''}`)
       .then(response => {
         setUsers(response.data.users)
         setZones(response.data.zones)
@@ -40,7 +40,7 @@ const CreateWorkOrder = () => {
         setLoading(false)
       })
       .catch(() => setLoading(false))
-  }, [])
+  }, [currentContract])
 
   const initialValues = {
     date: null,

--- a/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
+++ b/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
@@ -266,15 +266,7 @@ export default function WorkOrders() {
             }
             return (
               <div className="flex justify-end gap-2">
-                  <span className="p-overlay-badge" data-pr-tooltip={!currentContract || currentContract.id === 0 ? t('admin.tooltips.selectContract') : ''}>
-                    <Button 
-                    icon={<Icon icon="tabler:edit" />} 
-                    className="p-button-rounded p-button-primary" 
-                    onClick={() => navigate(`/admin/work-orders/edit/${rowData.id}`)} 
-                    title={t('admin.pages.workOrders.list.actions.edit')} 
-                    disabled={!currentContract || currentContract.id === 0}
-                    />
-                </span>
+                <Button icon={<Icon icon="tabler:edit" />} className="p-button-rounded p-button-primary" onClick={() => navigate(`/admin/work-orders/edit/${rowData.id}`)} title={t('admin.pages.workOrders.list.actions.edit')} />
                 <Button icon={<Icon icon="tabler:trash" />} className="p-button-rounded p-button-danger" onClick={() => handleDelete(rowData.id)} title={t('admin.pages.workOrders.list.actions.delete')} />
               </div>
             )


### PR DESCRIPTION
This pull request includes several changes to the `WorkOrderController`, seeders, and frontend components to improve the handling of contracts in work orders. The most important changes include updating the `create` and `update` methods in the `WorkOrderController`, modifying the `DatabaseSeeder` and `UserSeeder` classes, and enhancing the frontend logic in `AdminLayout`, `CreateWorkOrder`, `EditWorkOrder`, and `WorkOrders` components.

### Backend Changes:

* [`app/Http/Controllers/Api/Admin/WorkOrderController.php`](diffhunk://#diff-caef59b26d7256d70e5cc9452f7c58530c1ec841f904874ae1bcccd7a6e994e8R38-R50): Modified the `create` method to filter `users` and `zones` by `contract_id` if provided, and removed the `contract_id` requirement from the `update` method. [[1]](diffhunk://#diff-caef59b26d7256d70e5cc9452f7c58530c1ec841f904874ae1bcccd7a6e994e8R38-R50) [[2]](diffhunk://#diff-caef59b26d7256d70e5cc9452f7c58530c1ec841f904874ae1bcccd7a6e994e8L146) [[3]](diffhunk://#diff-caef59b26d7256d70e5cc9452f7c58530c1ec841f904874ae1bcccd7a6e994e8L161)

* [`database/seeders/DatabaseSeeder.php`](diffhunk://#diff-ccad8b4ee6013765c2bc672aa0515f8e99e42949c914cce01e0cb2b4e882775dR15-L19): Moved `ContractSeeder` to be called before the `UserSeeder`.

* [`database/seeders/UserSeeder.php`](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0L35-R35): Set specific `contract_id` values for worker users instead of `null`. [[1]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0L35-R35) [[2]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0L45-R45) [[3]](diffhunk://#diff-cb3ecc266735a477c6630f9db7ce33dac32dfc3af359c0264d092dd46f2210e0L65-R65)

### Frontend Changes:

* [`resources/ts/layouts/AdminLayout.tsx`](diffhunk://#diff-61d6d3d7ff0a74287a381aae865e43ee4ea65fcc701ad84509ef3600b32bf456R109-R112): Introduced `hideContractSelector` logic to conditionally hide the contract selector on specific pages. [[1]](diffhunk://#diff-61d6d3d7ff0a74287a381aae865e43ee4ea65fcc701ad84509ef3600b32bf456R109-R112) [[2]](diffhunk://#diff-61d6d3d7ff0a74287a381aae865e43ee4ea65fcc701ad84509ef3600b32bf456L236-R240) [[3]](diffhunk://#diff-61d6d3d7ff0a74287a381aae865e43ee4ea65fcc701ad84509ef3600b32bf456L302-R306)

* [`resources/ts/pages/Admin/WorkOrders/Create.tsx`](diffhunk://#diff-69bc5070c3402588e344e66886477704b40cf72d7a599eea47d9067637ca23faL33-R33): Updated the `CreateWorkOrder` component to include the `contract_id` in the request URL if a contract is selected. [[1]](diffhunk://#diff-69bc5070c3402588e344e66886477704b40cf72d7a599eea47d9067637ca23faL33-R33) [[2]](diffhunk://#diff-69bc5070c3402588e344e66886477704b40cf72d7a599eea47d9067637ca23faL43-R43)

* [`resources/ts/pages/Admin/WorkOrders/Edit.tsx`](diffhunk://#diff-5ac1957df8068a87e82def540c43366f954a5aacf91f699220fdf958a3b00fbeL57-R63): Enhanced the `EditWorkOrder` component to handle the `contract_id` of the work order and fetch related data accordingly. [[1]](diffhunk://#diff-5ac1957df8068a87e82def540c43366f954a5aacf91f699220fdf958a3b00fbeL57-R63) [[2]](diffhunk://#diff-5ac1957df8068a87e82def540c43366f954a5aacf91f699220fdf958a3b00fbeR87-R103) [[3]](diffhunk://#diff-5ac1957df8068a87e82def540c43366f954a5aacf91f699220fdf958a3b00fbeL131) [[4]](diffhunk://#diff-5ac1957df8068a87e82def540c43366f954a5aacf91f699220fdf958a3b00fbeL169-R177)

* [`resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx`](diffhunk://#diff-d190e1c2a6688700041966fe33222f6cf67c4ab66e2e38ccc0b13599decda475L269-R269): Removed the restriction that required a contract to be selected before editing a work order.…ents