### PR TITLE
chore(i18n): update password-related translations in Catalan and Spanish

### DIFF
--- a/resources/ts/config/i18n/ca.json
+++ b/resources/ts/config/i18n/ca.json
@@ -14,9 +14,9 @@
       "genus": "Gènere",
       "name": "Nom",
       "password": "Contrasenya",
-      "currentPassword": "Password (Current)",
-      "newPassword": "New Password",
-      "confirmPassword": "Confirm Password",
+      "currentPassword": "Contrasenya actual",
+      "newPassword": "Nova contrasenya",
+      "confirmPassword": "Confirmar contrasenya",
       "resource_type": "Tipus de recurs",
       "role": "Rol",
       "select_resource_type": "Selecciona un tipus de recurs",
@@ -566,7 +566,7 @@
           "currentPasswordRequired": "Has d'introduir la contrasenya actual",
           "newPasswordMinLength": "La contrasenya ha de tenir almenys 6 caràcters",
           "newPasswordMismatch": "Les contrasenyes no coincideixen",
-          "newPasswordComplexity": "New password must contain at least one uppercase letter, one lowercase letter, and one number"
+          "newPasswordComplexity": "La nova contrasenya ha de contenir almenys una lletra majúscula, una lletra minúscula i un número"
         },
         "messages": {
           "profileUpdated": "Perfil actualitzat correctament",

--- a/resources/ts/config/i18n/es.json
+++ b/resources/ts/config/i18n/es.json
@@ -14,9 +14,9 @@
       "genus": "Género",
       "name": "Nombre",
       "password": "Contraseña",
-      "currentPassword": "Password (Current)",
-      "newPassword": "New Password",
-      "confirmPassword": "Confirm Password",
+      "currentPassword": "Contraseña actual",
+      "newPassword": "Nueva contraseña",
+      "confirmPassword": "Confirmar contraseña",
       "resource_type": "Resource Type",
       "role": "Rol",
       "select_resource_type": "Selecciona un tipo de recurso",
@@ -566,7 +566,7 @@
           "currentPasswordRequired": "Debe ingresar la contraseña actual",
           "newPasswordMinLength": "La contraseña debe tener al menos 6 caracteres",
           "newPasswordMismatch": "Las contraseñas no coinciden",
-          "newPasswordComplexity": "New password must contain at least one uppercase letter, one lowercase letter, and one number"
+          "newPasswordComplexity": "La nueva contraseña debe contener al menos una letra mayúscula, una letra minúscula y un número"
         },
         "messages": {
           "profileUpdated": "Perfil actualizado correctamente",


### PR DESCRIPTION
This pull request includes changes to improve the localization of password-related text in the `ca.json` and `es.json` files. The most important changes involve updating the translations to be more accurate and consistent.

Localization updates:

* [`resources/ts/config/i18n/ca.json`](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L17-R19): Updated translations for "currentPassword", "newPassword", "confirmPassword", and "newPasswordComplexity" to improve accuracy and consistency. [[1]](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L17-R19) [[2]](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L569-R569)
* [`resources/ts/config/i18n/es.json`](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L17-R19): Updated translations for "currentPassword", "newPassword", "confirmPassword", and "newPasswordComplexity" to improve accuracy and consistency. [[1]](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L17-R19) [[2]](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L569-R569)