### PR TITLE
fix(auth): remove unnecessary dependency from useEffect in useAuth hook

### DIFF
--- a/resources/ts/hooks/useAuth.ts
+++ b/resources/ts/hooks/useAuth.ts
@@ -19,7 +19,7 @@ export function useAuth() {
         } else {
             setIsLoading(false);
         }
-    }, [user.id]);
+    }, []);
 
     const fetchUser = async (navigate?: (path: string) => void) => {
         try {


### PR DESCRIPTION
This pull request includes a small change to the `useAuth` function in the `resources/ts/hooks/useAuth.ts` file. The change removes the dependency on `user.id` from the `useEffect` dependency array, ensuring that the effect only runs once when the component mounts.

* [`resources/ts/hooks/useAuth.ts`](diffhunk://#diff-fb7e7abb5d7fb941eb83fe9e93759edd8ba87c45ff771a5fb97795f8d9c12418L22-R22): Removed `user.id` from the dependency array in the `useEffect` hook to ensure the effect only runs on mount.