### PR TITLE
fix(i18n): correct translation keys from 'evas' to 'eva' in English

### DIFF
--- a/resources/ts/config/i18n/ca.json
+++ b/resources/ts/config/i18n/ca.json
@@ -608,122 +608,122 @@
           "passwordCurrentWrong": "La contrasenya actual no coincideix"
         }
       },
-      "evas": {
+      "eva": {
         "show": {
-          "title": "Eva Details"
+          "title": "Detalls de l'Eva"
         },
         "dictionaries": {
           "copaDesequilibrada": {
-            "0": "No inclination or uneven growth",
-            "1": "Slight crown inclination",
-            "2": "Visibly inclined crown",
-            "3": "Extremely inclined crown"
+            "0": "Sense inclinació ni creixement desigual",
+            "1": "Lleugera inclinació de la capçada",
+            "2": "Capçada visiblement inclinada",
+            "3": "Capçada extremadament inclinada"
           },
           "ramasSobreextendidas": {
-            "0": "Well-structured branches",
-            "1": "Few overextended branches",
-            "2": "Several overextended branches",
-            "3": "Overextended and heavy branches"
+            "0": "Branques ben estructurades",
+            "1": "Poques branques sobreesteses",
+            "2": "Diverses branques sobreesteses",
+            "3": "Branques sobreesteses i pesades"
           },
           "grietas": {
-            "0": "No cracks",
-            "1": "Small cracks in the trunk",
-            "2": "Visible cracks in several parts",
-            "3": "Deep cracks in the trunk"
+            "0": "Sense esquerdes",
+            "1": "Petites esquerdes al tronc",
+            "2": "Esquerdes visibles en diverses parts",
+            "3": "Esquerdes profundes al tronc"
           },
           "ramasMuertas": {
-            "0": "No dead branches",
-            "1": "Some dead branches",
-            "2": "Multiple dead branches",
-            "3": "Large number of dead branches"
+            "0": "Sense branques mortes",
+            "1": "Algunes branques mortes",
+            "2": "Múltiples branques mortes",
+            "3": "Gran quantitat de branques mortes"
           },
           "inclinacion": {
-            "0": "Completely vertical",
-            "1": "Slight inclination (<5°)",
-            "2": "Moderate inclination (5-15°)",
-            "3": "High inclination (>15°)"
+            "0": "Completament vertical",
+            "1": "Lleugera inclinació (<5°)",
+            "2": "Inclinació moderada (5-15°)",
+            "3": "Alta inclinació (>15°)"
           },
           "bifurcacionesV": {
-            "0": "Normal bifurcations",
-            "1": "Slight V bifurcation",
-            "2": "Pronounced V bifurcation",
-            "3": "Dangerous V bifurcation"
+            "0": "Bifurcacions normals",
+            "1": "Lleugera bifurcació en V",
+            "2": "Bifurcació en V pronunciada",
+            "3": "Bifurcació en V perillosa"
           },
           "cavidades": {
-            "0": "No cavities",
-            "1": "Small cavity",
-            "2": "Intermediate cavity",
-            "3": "Deep and structural cavity"
+            "0": "Sense cavitats",
+            "1": "Cavitat petita",
+            "2": "Cavitat intermèdia",
+            "3": "Cavitat profunda i estructural"
           },
           "danosCorteza": {
-            "0": "Intact bark",
-            "1": "Bark with slight wounds",
-            "2": "Significant bark damage",
-            "3": "Very damaged bark"
+            "0": "Escorça intacta",
+            "1": "Escorça amb ferides lleus",
+            "2": "Dany significatiu a l'escorça",
+            "3": "Escorça molt danyada"
           },
           "levantamientoSuelo": {
-            "0": "Soil without alterations",
-            "1": "Slight soil elevation",
-            "2": "Visible soil elevation",
-            "3": "Severely lifted soil"
+            "0": "Sòl sense alteracions",
+            "1": "Lleu elevació del sòl",
+            "2": "Elevació visible del sòl",
+            "3": "Sòl severament aixecat"
           },
           "raicesCortadas": {
-            "0": "Intact roots",
-            "1": "Roots with slight cuts",
-            "2": "Partially damaged roots",
-            "3": "Severely cut roots"
+            "0": "Arrels intactes",
+            "1": "Arrels amb talls lleus",
+            "2": "Arrels parcialment danyades",
+            "3": "Arrels severament tallades"
           },
           "podredumbreBasal": {
-            "0": "No rot",
-            "1": "Initial rot",
-            "2": "Visible rot",
-            "3": "Advanced rot"
+            "0": "Sense podridura",
+            "1": "Podridura inicial",
+            "2": "Podridura visible",
+            "3": "Podridura avançada"
           },
           "raicesExpuestas": {
-            "0": "Roots underground",
-            "1": "Some exposed roots",
-            "2": "Several exposed roots",
-            "3": "Exposed and weakened roots"
+            "0": "Arrels sota terra",
+            "1": "Algunes arrels exposades",
+            "2": "Diverses arrels exposades",
+            "3": "Arrels exposades i debilitades"
           },
           "viento": {
-            "0": "Tree protected by natural barriers or buildings, no strong constant wind.",
-            "1": "Tree with occasional wind but no significant impact on its stability.",
-            "2": "Tree exposed to frequent strong winds, which may affect its structure.",
-            "3": "Tree in open areas or slopes where the wind blows with extreme force."
+            "0": "Arbre protegit per barreres naturals o edificis, sense vent constant fort.",
+            "1": "Arbre amb vent ocasional però sense impacte significatiu en la seva estabilitat.",
+            "2": "Arbre exposat a vents forts freqüents, que poden afectar la seva estructura.",
+            "3": "Arbre en zones obertes o pendents on el vent bufa amb força extrema."
           },
           "sequia": {
-            "0": "Tree in an area with stable humidity and constant access to water, no water stress.",
-            "1": "Tree with moderate access to water, but with occasional drought periods.",
-            "2": "Tree in an area with recurrent droughts, affecting its development and resistance.",
-            "3": "Tree in an arid area or with prolonged droughts, high risk of weakening."
+            "0": "Arbre en una zona amb humitat estable i accés constant a l'aigua, sense estrès hídric.",
+            "1": "Arbre amb accés moderat a l'aigua, però amb períodes ocasionals de sequera.",
+            "2": "Arbre en una zona amb sequeres recurrents, afectant el seu desenvolupament i resistència.",
+            "3": "Arbre en una zona àrida o amb sequeres prolongades, alt risc de debilitament."
           }
         },
         "edit": {
-          "title": "Edit Eva",
-          "identification": "Identification",
-          "treeCondition": "Tree Condition",
+          "title": "Edita Eva",
+          "identification": "Identificació",
+          "treeCondition": "Condició de l'Arbre",
           "dimensions": "Dimensions",
-          "state": "State",
-          "crownBranches": "Crown and Branches",
-          "trunk": "Trunk",
-          "roots": "Roots",
-          "environmentCondition": "Environment Condition",
-          "environmentalFactors": "Environmental Factors",
-          "windExposure": "Wind Exposure",
-          "droughtExposure": "Drought Exposure"
+          "state": "Estat",
+          "crownBranches": "Capçada i Branques",
+          "trunk": "Tronc",
+          "roots": "Arrels",
+          "environmentCondition": "Condició de l'Entorn",
+          "environmentalFactors": "Factors Ambientals",
+          "windExposure": "Exposició al Vent",
+          "droughtExposure": "Exposició a la Sequera"
         },
         "create": {
-          "identification": "Identification",
-          "treeCondition": "Tree Condition",
+          "identification": "Identificació",
+          "treeCondition": "Condició de l'Arbre",
           "dimensions": "Dimensions",
-          "state": "State",
-          "crownBranches": "Crown and Branches",
-          "trunk": "Trunk",
-          "roots": "Roots",
-          "environmentCondition": "Environment Condition",
-          "environmentalFactors": "Environmental Factors",
-          "windExposure": "Wind Exposure",
-          "droughtExposure": "Drought Exposure"
+          "state": "Estat",
+          "crownBranches": "Capçada i Branques",
+          "trunk": "Tronc",
+          "roots": "Arrels",
+          "environmentCondition": "Condició de l'Entorn",
+          "environmentalFactors": "Factors Ambientals",
+          "windExposure": "Exposició al Vent",
+          "droughtExposure": "Exposició a la Sequera"
         },
         "title": "Evas",
         "age": {

--- a/resources/ts/config/i18n/en.json
+++ b/resources/ts/config/i18n/en.json
@@ -575,7 +575,7 @@
           "passwordCurrentWrong": "Current password is incorrect"
         }
       },
-      "evas": {
+      "eva": {
         "show": {
           "title": "Eva Details"
         },

--- a/resources/ts/config/i18n/es.json
+++ b/resources/ts/config/i18n/es.json
@@ -587,94 +587,94 @@
           "passwordCurrentWrong": "La contraseña actual no coincide"
         }
       },
-      "evas": {
+      "eva": {
         "show": {
-          "title": "Eva Details"
+          "title": "Detalles de Eva"
         },
         "dictionaries": {
           "copaDesequilibrada": {
-            "0": "No inclination or uneven growth",
-            "1": "Slight crown inclination",
-            "2": "Visibly inclined crown",
-            "3": "Extremely inclined crown"
+            "0": "Sin inclinación ni crecimiento desigual",
+            "1": "Ligera inclinación de la copa",
+            "2": "Copa visiblemente inclinada",
+            "3": "Copa extremadamente inclinada"
           },
           "ramasSobreextendidas": {
-            "0": "Well-structured branches",
-            "1": "Few overextended branches",
-            "2": "Several overextended branches",
-            "3": "Overextended and heavy branches"
+            "0": "Ramas bien estructuradas",
+            "1": "Pocas ramas sobreextendidas",
+            "2": "Varias ramas sobreextendidas",
+            "3": "Ramas sobreextendidas y pesadas"
           },
           "grietas": {
-            "0": "No cracks",
-            "1": "Small cracks in the trunk",
-            "2": "Visible cracks in several parts",
-            "3": "Deep cracks in the trunk"
+            "0": "Sin grietas",
+            "1": "Pequeñas grietas en el tronco",
+            "2": "Grietas visibles en varias partes",
+            "3": "Grietas profundas en el tronco"
           },
           "ramasMuertas": {
-            "0": "No dead branches",
-            "1": "Some dead branches",
-            "2": "Multiple dead branches",
-            "3": "Large number of dead branches"
+            "0": "Sin ramas muertas",
+            "1": "Algunas ramas muertas",
+            "2": "Múltiples ramas muertas",
+            "3": "Gran cantidad de ramas muertas"
           },
           "inclinacion": {
-            "0": "Completely vertical",
-            "1": "Slight inclination (<5°)",
-            "2": "Moderate inclination (5-15°)",
-            "3": "High inclination (>15°)"
+            "0": "Completamente vertical",
+            "1": "Ligera inclinación (<5°)",
+            "2": "Inclinación moderada (5-15°)",
+            "3": "Alta inclinación (>15°)"
           },
           "bifurcacionesV": {
-            "0": "Normal bifurcations",
-            "1": "Slight V bifurcation",
-            "2": "Pronounced V bifurcation",
-            "3": "Dangerous V bifurcation"
+            "0": "Bifurcaciones normales",
+            "1": "Ligera bifurcación en V",
+            "2": "Bifurcación en V pronunciada",
+            "3": "Bifurcación en V peligrosa"
           },
           "cavidades": {
-            "0": "No cavities",
-            "1": "Small cavity",
-            "2": "Intermediate cavity",
-            "3": "Deep and structural cavity"
+            "0": "Sin cavidades",
+            "1": "Cavidad pequeña",
+            "2": "Cavidad intermedia",
+            "3": "Cavidad profunda y estructural"
           },
           "danosCorteza": {
-            "0": "Intact bark",
-            "1": "Bark with slight wounds",
-            "2": "Significant bark damage",
-            "3": "Very damaged bark"
+            "0": "Corteza intacta",
+            "1": "Corteza con heridas leves",
+            "2": "Daño significativo en la corteza",
+            "3": "Corteza muy dañada"
           },
           "levantamientoSuelo": {
-            "0": "Soil without alterations",
-            "1": "Slight soil elevation",
-            "2": "Visible soil elevation",
-            "3": "Severely lifted soil"
+            "0": "Suelo sin alteraciones",
+            "1": "Leve elevación del suelo",
+            "2": "Elevación visible del suelo",
+            "3": "Suelo severamente levantado"
           },
           "raicesCortadas": {
-            "0": "Intact roots",
-            "1": "Roots with slight cuts",
-            "2": "Partially damaged roots",
-            "3": "Severely cut roots"
+            "0": "Raíces intactas",
+            "1": "Raíces con cortes leves",
+            "2": "Raíces parcialmente dañadas",
+            "3": "Raíces severamente cortadas"
           },
           "podredumbreBasal": {
-            "0": "No rot",
-            "1": "Initial rot",
-            "2": "Visible rot",
-            "3": "Advanced rot"
+            "0": "Sin podredumbre",
+            "1": "Podredumbre inicial",
+            "2": "Podredumbre visible",
+            "3": "Podredumbre avanzada"
           },
           "raicesExpuestas": {
-            "0": "Roots underground",
-            "1": "Some exposed roots",
-            "2": "Several exposed roots",
-            "3": "Exposed and weakened roots"
+            "0": "Raíces bajo tierra",
+            "1": "Algunas raíces expuestas",
+            "2": "Varias raíces expuestas",
+            "3": "Raíces expuestas y debilitadas"
           },
           "viento": {
-            "0": "Tree protected by natural barriers or buildings, no strong constant wind.",
-            "1": "Tree with occasional wind but no significant impact on its stability.",
-            "2": "Tree exposed to frequent strong winds, which may affect its structure.",
-            "3": "Tree in open areas or slopes where the wind blows with extreme force."
+            "0": "Árbol protegido por barreras naturales o edificios, sin viento constante fuerte.",
+            "1": "Árbol con viento ocasional pero sin impacto significativo en su estabilidad.",
+            "2": "Árbol expuesto a vientos fuertes frecuentes, lo que puede afectar su estructura.",
+            "3": "Árbol en áreas abiertas o pendientes donde el viento sopla con fuerza extrema."
           },
           "sequia": {
-            "0": "Tree in an area with stable humidity and constant access to water, no water stress.",
-            "1": "Tree with moderate access to water, but with occasional drought periods.",
-            "2": "Tree in an area with recurrent droughts, affecting its development and resistance.",
-            "3": "Tree in an arid area or with prolonged droughts, high risk of weakening."
+            "0": "Árbol en un área con humedad estable y acceso constante al agua, sin estrés hídrico.",
+            "1": "Árbol con acceso moderado al agua, pero con períodos ocasionales de sequía.",
+            "2": "Árbol en un área con sequías recurrentes, afectando su desarrollo y resistencia.",
+            "3": "Árbol en un área árida o con sequías prolongadas, alto riesgo de debilitamiento."
           }
         },
         "edit": {

--- a/resources/ts/pages/Admin/Eva/Show.tsx
+++ b/resources/ts/pages/Admin/Eva/Show.tsx
@@ -266,7 +266,7 @@ export default function ShowEva() {
               <Icon icon="tabler:arrow-left" className="h-6 w-6" />
             </Button>
             <h2 className="text-white text-3xl font-bold">
-              {t('admin.pages.evas.show.title')}
+              {t('admin.pages.eva.show.title')}
             </h2>
           </div>
           <Button

--- a/resources/ts/routes/AdminRoutes.tsx
+++ b/resources/ts/routes/AdminRoutes.tsx
@@ -81,7 +81,7 @@ const AdminRoutes: RouteObject[] = [
           {
             path: 'evas/:id',
             element: (
-              <AdminLayoutWrapper titleI18n="admin.pages.evas.show.title">
+              <AdminLayoutWrapper titleI18n="admin.pages.eva.show.title">
                 <ShowEva />
               </AdminLayoutWrapper>
             ),


### PR DESCRIPTION
This pull request includes updates to the internationalization files and related components to improve the consistency and accuracy of translations across multiple languages. The most important changes involve renaming keys and updating translations in the `ca.json`, `en.json`, and `es.json` files, as well as modifying the related components to reflect these changes.

Updates to internationalization files:

* [`resources/ts/config/i18n/ca.json`](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L611-R726): Renamed "evas" to "eva" and updated translations for various tree condition descriptions.
* [`resources/ts/config/i18n/en.json`](diffhunk://#diff-75fa9e3a78347c6cd6a747ef879348f248881628a32d8926eba7a5036998bba3L578-R578): Renamed "evas" to "eva" and updated the title for the show page.
* [`resources/ts/config/i18n/es.json`](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L590-R677): Renamed "evas" to "eva" and updated translations for various tree condition descriptions.

Component updates:

* [`resources/ts/pages/Admin/Eva/Show.tsx`](diffhunk://#diff-b4fff59098b836c3329d0fe4fcc088eb55472b8404d73cb904a463768201b0d0L269-R269): Updated the title translation key from "evas.show.title" to "eva.show.title".
* [`resources/ts/routes/AdminRoutes.tsx`](diffhunk://#diff-b0d509f134a8f2eef094f42cf905df35ec7948496ad63e7d67846df17d9f38c2L84-R84): Updated the route title translation key from "evas.show.title" to "eva.show.title".