### PR TITLE
fix: translations

### DIFF
--- a/resources/ts/config/i18n/ca.json
+++ b/resources/ts/config/i18n/ca.json
@@ -208,9 +208,9 @@
             "name_required": "El nom és obligatori",
             "type_invalid": "Si us plau, selecciona un tipus de recurs vàlid",
             "type_required": "El tipus és obligatori",
-            "unit_cost_min": "Unit cost must be greater than 0",
-            "unit_cost_required": "Unit cost is required",
-            "unit_name_required": "Unit name is required"
+            "unit_cost_min": "El cost unitari ha de ser major que 0",
+            "unit_cost_required": "El cost unitari és obligatori",
+            "unit_name_required": "El nom de la unitat és obligatori"
           }
         },
         "list": {
@@ -224,8 +224,8 @@
             "name": "Nom",
             "type": "Tipus",
             "unit": "Unitat",
-            "unit_name": "Unit Name",
-            "unit_cost": "Unit Cost"
+            "unit_name": "Nom de la unitat",
+            "unit_cost": "Cost unitari"
           },
           "messages": {
             "createSuccess": "Tipus de recurs creat correctament",
@@ -295,7 +295,7 @@
         "hoursWorked": "Hores Treballades",
         "fuelConsumption": "Consum de Combustible",
         "noData": "No hi ha dades per mostrar",
-        "exportCSV": "Export to CSV"
+        "exportCSV": "Exportar a CSV"
       },
       "taskTypes": {
         "form": {

--- a/resources/ts/config/i18n/es.json
+++ b/resources/ts/config/i18n/es.json
@@ -208,9 +208,9 @@
             "name_required": "El nombre es obligatorio",
             "type_invalid": "Por favor, selecciona un tipo de recurso válido",
             "type_required": "El tipo es obligatorio",
-            "unit_cost_min": "Unit cost must be greater than 0",
-            "unit_cost_required": "Unit cost is required",
-            "unit_name_required": "Unit name is required"
+            "unit_cost_min": "El costo unitario debe ser mayor que 0",
+            "unit_cost_required": "El costo unitario es obligatorio",
+            "unit_name_required": "El nombre de la unidad es obligatorio"
           }
         },
         "list": {
@@ -224,8 +224,8 @@
             "name": "Nombre",
             "type": "Tipo",
             "unit": "Unidad",
-            "unit_name": "Unit Name",
-            "unit_cost": "Unit Cost"
+            "unit_name": "Nombre de la unidad",
+            "unit_cost": "Costo unitario"
           },
           "messages": {
             "createSuccess": "Recurso creado exitosamente",
@@ -295,7 +295,7 @@
         "hoursWorked": "Horas Trabajadas",
         "fuelConsumption": "Consumo de Combustible",
         "noData": "No hay datos para mostrar",
-        "exportCSV": "Export to CSV"
+        "exportCSV": "Exportar a CSV"
       },
       "taskTypes": {
         "form": {


### PR DESCRIPTION
This pull request includes updates to the Catalan and Spanish translations in the `resources/ts/config/i18n` directory. The changes ensure that the translations are accurate and consistent.

Updates to Catalan translations:

* [`resources/ts/config/i18n/ca.json`](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L211-R213): Corrected translations for several resource-related messages, including "unit cost", "unit name", and "export to CSV". [[1]](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L211-R213) [[2]](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L227-R228) [[3]](diffhunk://#diff-3822e87aba8184976f5aaf0175f134591a0a92a8e8637f20c19f249a71167a85L298-R298)

Updates to Spanish translations:

* [`resources/ts/config/i18n/es.json`](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L211-R213): Corrected translations for several resource-related messages, including "unit cost", "unit name", and "export to CSV". [[1]](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L211-R213) [[2]](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L227-R228) [[3]](diffhunk://#diff-db19a2b522ebee2953f9c96329f0090c6e63dc155903585c7b618220ad3998a6L298-R298)…zing rsync options