### PR TITLE
Feat: workorder disable edit

### DIFF
--- a/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
+++ b/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
@@ -317,11 +317,12 @@ export default function WorkOrders() {
 
   const actionButtons = useCallback(
     (rowData: WorkOrder) => {
-      const isEditable = rowData.status !== 1 && rowData.status !== 2;
+      const isEditable = rowData.status !== 1 && rowData.status !== 2 && rowData.status !== 3;
+      const canViewReport = rowData.status === 1 || rowData.status === 2 || rowData.status === 3;
 
       return (
         <div className="flex justify-end gap-2">
-          {isEditable ? (
+          {isEditable && (
             <>
               <Button
                 icon={<Icon icon="tabler:edit" />}
@@ -338,7 +339,8 @@ export default function WorkOrders() {
                 title={t('admin.pages.workOrders.list.actions.delete')}
               />
             </>
-          ) : (
+          )}
+          {canViewReport && (
             <Button
               icon={<Icon icon="tabler:file-text" />}
               className="p-button-rounded p-button-info"

--- a/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
+++ b/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
@@ -317,32 +317,35 @@ export default function WorkOrders() {
 
   const actionButtons = useCallback(
     (rowData: WorkOrder) => {
-      if (rowData.status === 3) {
-        return (
-          <div className="flex justify-end gap-2">
+      const isEditable = rowData.status !== 1 && rowData.status !== 2; // 1: In Progress, 2: Completed
+
+      return (
+        <div className="flex justify-end gap-2">
+          {isEditable ? (
+            <>
+              <Button
+                icon={<Icon icon="tabler:edit" />}
+                className="p-button-rounded p-button-primary"
+                onClick={() =>
+                  navigate(`/admin/work-orders/edit/${rowData.id}`)
+                }
+                title={t('admin.pages.workOrders.list.actions.edit')}
+              />
+              <Button
+                icon={<Icon icon="tabler:trash" />}
+                className="p-button-rounded p-button-danger"
+                onClick={() => handleDelete(rowData.id)}
+                title={t('admin.pages.workOrders.list.actions.delete')}
+              />
+            </>
+          ) : (
             <Button
               icon={<Icon icon="tabler:eye" />}
               className="p-button-rounded p-button-info"
               onClick={() => navigate(`/admin/work-reports/${rowData.id}`)}
               title={t('admin.pages.workOrders.list.actions.viewReport')}
             />
-          </div>
-        );
-      }
-      return (
-        <div className="flex justify-end gap-2">
-          <Button
-            icon={<Icon icon="tabler:edit" />}
-            className="p-button-rounded p-button-primary"
-            onClick={() => navigate(`/admin/work-orders/edit/${rowData.id}`)}
-            title={t('admin.pages.workOrders.list.actions.edit')}
-          />
-          <Button
-            icon={<Icon icon="tabler:trash" />}
-            className="p-button-rounded p-button-danger"
-            onClick={() => handleDelete(rowData.id)}
-            title={t('admin.pages.workOrders.list.actions.delete')}
-          />
+          )}
         </div>
       );
     },

--- a/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
+++ b/resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx
@@ -317,7 +317,7 @@ export default function WorkOrders() {
 
   const actionButtons = useCallback(
     (rowData: WorkOrder) => {
-      const isEditable = rowData.status !== 1 && rowData.status !== 2; // 1: In Progress, 2: Completed
+      const isEditable = rowData.status !== 1 && rowData.status !== 2;
 
       return (
         <div className="flex justify-end gap-2">
@@ -340,7 +340,7 @@ export default function WorkOrders() {
             </>
           ) : (
             <Button
-              icon={<Icon icon="tabler:eye" />}
+              icon={<Icon icon="tabler:file-text" />}
               className="p-button-rounded p-button-info"
               onClick={() => navigate(`/admin/work-reports/${rowData.id}`)}
               title={t('admin.pages.workOrders.list.actions.viewReport')}


### PR DESCRIPTION
This pull request includes changes to the `WorkOrders` component in the `resources/ts/pages/Admin/WorkOrders/WorkOrders.tsx` file. The main objective of these changes is to enhance the action buttons' behavior based on the status of the work order.

Key changes include:

* Added new conditions to determine if the work order is editable or if the report can be viewed based on the status of the work order.
* Updated the rendering logic to conditionally display the edit and delete buttons only if the work order is editable.
* Updated the rendering logic to conditionally display the view report button if the work order status allows viewing the report.