### PR TITLE
fix: standardize variable naming for EVA attributes

### DIFF
--- a/resources/ts/components/FuncionesEva.tsx
+++ b/resources/ts/components/FuncionesEva.tsx
@@ -1,0 +1,221 @@
+// TreeEvaluationFunctions.tsx
+import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
+
+interface EvaluationResult {
+  message: string;
+  color: string;
+}
+
+interface Eva {
+  element_id: number;
+  date_birth: string;
+  height: number;
+  diameter: number;
+  crown_width: number;
+  crown_projection_area: number;
+  root_surface_diameter: number;
+  effective_root_area: number;
+  height_estimation: number;
+  unbalanced_crown: number;
+  overextended_branches: number;
+  cracks: number;
+  dead_branches: number;
+  inclination: number;
+  V_forks: number;
+  cavities: number;
+  bark_damage: number;
+  soil_lifting: number;
+  cut_damaged_roots: number;
+  basal_rot: number;
+  exposed_surface_roots: number;
+  wind: number;
+  drought: number;
+  status: number;
+}
+
+export const useTreeEvaluation = () => {
+  const { t } = useTranslation();
+
+  const getStatusMessage = (status: number): EvaluationResult => {
+    const percentage = (status / 36) * 100;
+    if (percentage == 0 && percentage <= 24) {
+      return { message: t('admin.pages.evas.status.low'), color: '#6AA84F' };
+    }
+    if (percentage >= 25 && percentage <= 49) {
+      return {
+        message: t('admin.pages.evas.status.moderate'),
+        color: '#00FF00',
+      };
+    }
+    if (percentage >= 50 && percentage <= 74) {
+      return { message: t('admin.pages.evas.status.high'), color: '#FFFF00' };
+    }
+    if (percentage >= 75 && percentage <= 100) {
+      return {
+        message: t('admin.pages.evas.status.critical'),
+        color: '#FF0000',
+      };
+    }
+    return { message: t('admin.pages.evas.status.pending'), color: 'gray' };
+  };
+
+  const calculateStabilityIndex = (
+    height: number,
+    diameter: number,
+  ): EvaluationResult => {
+    const index = (height / diameter) * 100;
+    if (index < 50) {
+      return {
+        message: t('admin.pages.evas.stability.stable'),
+        color: '#6AA84F',
+      };
+    } else if (index >= 50 && index <= 80) {
+      return {
+        message: t('admin.pages.evas.stability.moderate'),
+        color: '#00FF00',
+      };
+    } else if (index > 80) {
+      return {
+        message: t('admin.pages.evas.stability.highRisk'),
+        color: '#FF0000',
+      };
+    } else {
+      return {
+        message: t('admin.pages.evas.stability.pending'),
+        color: 'gray',
+      };
+    }
+  };
+
+  const calculateGravityHeightRatio = (
+    heightEstimation: number,
+    height: number,
+  ): EvaluationResult => {
+    const ratio = heightEstimation / height;
+    if (ratio < 0.3) {
+      return {
+        message: t('admin.pages.evas.gravityHeight.veryStable'),
+        color: '#6AA84F',
+      };
+    } else if (ratio >= 0.3 && ratio <= 0.5) {
+      return {
+        message: t('admin.pages.evas.gravityHeight.moderateRisk'),
+        color: '#00FF00',
+      };
+    } else if (ratio > 0.5) {
+      return {
+        message: t('admin.pages.evas.gravityHeight.highRisk'),
+        color: '#FF0000',
+      };
+    } else {
+      return {
+        message: t('admin.pages.evas.gravityHeight.pending'),
+        color: 'gray',
+      };
+    }
+  };
+
+  const calculateRootCrownRatio = (
+    effective_root_area: number,
+    crown_projection_area: number,
+  ): EvaluationResult => {
+    const ratio = effective_root_area / crown_projection_area;
+    if (ratio > 2) {
+      return {
+        message: t('admin.pages.evas.rootCrown.veryStable'),
+        color: '#6AA84F',
+      };
+    } else if (ratio > 1.5 && ratio <= 2) {
+      return {
+        message: t('admin.pages.evas.rootCrown.stable'),
+        color: '#00FF00',
+      };
+    } else if (ratio > 1 && ratio <= 1.5) {
+      return {
+        message: t('admin.pages.evas.rootCrown.moderateStability'),
+        color: '#FFFF00',
+      };
+    } else if (ratio <= 1) {
+      return {
+        message: t('admin.pages.evas.rootCrown.highRisk'),
+        color: '#FF0000',
+      };
+    } else {
+      return {
+        message: t('admin.pages.evas.rootCrown.pending'),
+        color: 'gray',
+      };
+    }
+  };
+
+  const calculateWindStabilityIndex = (
+    height: number,
+    wind: number,
+    rootSurfaceDiameter: number,
+  ): EvaluationResult => {
+    const index = (height * wind) / rootSurfaceDiameter;
+    if (index < 0.5) {
+      return {
+        message: t('admin.pages.evas.windStability.veryStable'),
+        color: '#6AA84F',
+      };
+    } else if (index >= 0.5 && index <= 1) {
+      return {
+        message: t('admin.pages.evas.windStability.moderateStability'),
+        color: '#FFFF00',
+      };
+    } else if (index > 1) {
+      return {
+        message: t('admin.pages.evas.windStability.highRisk'),
+        color: '#FF0000',
+      };
+    } else {
+      return {
+        message: t('admin.pages.evas.windStability.pending'),
+        color: 'gray',
+      };
+    }
+  };
+
+  const getSeverityMessage = (value: number): EvaluationResult => {
+    switch (value) {
+      case 0:
+        return {
+          message: t('admin.pages.evas.severity.low'),
+          color: '#6AA84F',
+        };
+      case 1:
+        return {
+          message: t('admin.pages.evas.severity.moderate'),
+          color: '#00FF00',
+        };
+      case 2:
+        return {
+          message: t('admin.pages.evas.severity.high'),
+          color: '#FFFF00',
+        };
+      case 3:
+        return {
+          message: t('admin.pages.evas.severity.extreme'),
+          color: '#FF0000',
+        };
+      default:
+        return {
+          message: t('admin.pages.evas.severity.pending'),
+          color: 'gray',
+        };
+    }
+  };
+
+  return {
+    getStatusMessage,
+    calculateStabilityIndex,
+    calculateGravityHeightRatio,
+    calculateRootCrownRatio,
+    calculateWindStabilityIndex,
+    getSeverityMessage,
+  };
+};
+
+export type { Eva };

--- a/resources/ts/components/FuncionesEva.tsx
+++ b/resources/ts/components/FuncionesEva.tsx
@@ -1,4 +1,3 @@
-// TreeEvaluationFunctions.tsx
 import { t } from 'i18next';
 import { useTranslation } from 'react-i18next';
 

--- a/resources/ts/pages/Admin/Eva/Create.tsx
+++ b/resources/ts/pages/Admin/Eva/Create.tsx
@@ -14,7 +14,6 @@ import { useTranslation } from 'react-i18next';
 import { Message } from 'primereact/message';
 import { subYears, subMonths, format } from 'date-fns';
 
-// Componente FormField para manejar campos del formulario
 const FormField = ({ as: Component, name, label, ...props }: any) => {
   const [field, meta, helpers] = useField(name);
 

--- a/resources/ts/pages/Admin/Eva/Create.tsx
+++ b/resources/ts/pages/Admin/Eva/Create.tsx
@@ -210,6 +210,15 @@ const CreateEva = () => {
         ...values,
         date_birth: formattedDate,
         status,
+        unbalanced_crown: values.unbalancedCrown,
+        overextended_branches: values.overextendedBranches,
+        dead_branches: values.deadBranches,
+        V_forks: values.VForks,
+        bark_damage: values.barkDamage,
+        soil_lifting: values.soilLifting,
+        cut_damaged_roots: values.cutRoots,
+        basal_rot: values.basalRot,
+        exposed_surface_roots: values.exposedRoots,
       };
 
       await axiosClient.post('/admin/evas', updatedValues);

--- a/resources/ts/pages/Admin/Eva/Create.tsx
+++ b/resources/ts/pages/Admin/Eva/Create.tsx
@@ -280,7 +280,7 @@ const CreateEva = () => {
                     label={t('admin.pages.evas.form.name')}
                     as={Dropdown}
                     options={elements.map((element) => ({
-                      label: element.name,
+                      label: element.id,
                       value: element.id,
                     }))}
                     optionLabel="label"

--- a/resources/ts/pages/Admin/Eva/Edit.tsx
+++ b/resources/ts/pages/Admin/Eva/Edit.tsx
@@ -265,18 +265,18 @@ export default function EditEva() {
       const formattedDate = format(birthDate, 'yyyy-MM-dd');
 
       const status =
-        Number(values.unbalanced_crown) +
-        Number(values.overextended_branches) +
-        Number(values.cracks) +
-        Number(values.dead_branches) +
-        Number(values.inclination) +
-        Number(values.V_forks) +
-        Number(values.cavities) +
-        Number(values.bark_damage) +
-        Number(values.soil_lifting) +
-        Number(values.cut_damaged_roots) +
-        Number(values.basal_rot) +
-        Number(values.exposed_surface_roots);
+        Number(values.unbalanced_crown || 0) +
+        Number(values.overextended_branches || 0) +
+        Number(values.cracks || 0) +
+        Number(values.dead_branches || 0) +
+        Number(values.inclination || 0) +
+        Number(values.V_forks || 0) +
+        Number(values.cavities || 0) +
+        Number(values.bark_damage || 0) +
+        Number(values.soil_lifting || 0) +
+        Number(values.cut_damaged_roots || 0) +
+        Number(values.basal_rot || 0) +
+        Number(values.exposed_surface_roots || 0);
 
       const updatedValues = {
         ...values,
@@ -284,7 +284,20 @@ export default function EditEva() {
         status: status,
       };
 
-      await axiosClient.put(`/admin/evas/${id}`, updatedValues);
+      // Ensure all required fields are included and properly formatted
+      const payload = {
+        ...updatedValues,
+        element_id: Number(updatedValues.element_id),
+        height: Number(updatedValues.height),
+        diameter: Number(updatedValues.diameter),
+        crown_width: Number(updatedValues.crown_width),
+        crown_projection_area: Number(updatedValues.crown_projection_area),
+        root_surface_diameter: Number(updatedValues.root_surface_diameter),
+        effective_root_area: Number(updatedValues.effective_root_area),
+        height_estimation: Number(updatedValues.height_estimation),
+      };
+
+      await axiosClient.put(`/admin/evas/${id}`, payload);
       navigate(`/admin/evas/${id}`, {
         state: { success: t('messages.updateSuccess') },
       });

--- a/resources/ts/pages/Admin/Eva/Edit.tsx
+++ b/resources/ts/pages/Admin/Eva/Edit.tsx
@@ -135,18 +135,18 @@ export default function EditEva() {
     root_surface_diameter: 0,
     effective_root_area: 0,
     height_estimation: 0,
-    unbalancedCrown: 0,
-    overextendedBranches: 0,
+    unbalanced_crown: 0, // Cambiado de unbalancedCrown
+    overextended_branches: 0, // Cambiado de overextendedBranches
     cracks: 0,
-    deadBranches: 0,
+    dead_branches: 0, // Cambiado de deadBranches
     inclination: 0,
-    VForks: 0,
+    V_forks: 0, // Cambiado de VForks
     cavities: 0,
-    barkDamage: 0,
-    soilLifting: 0,
-    cutRoots: 0,
-    basalRot: 0,
-    exposedRoots: 0,
+    bark_damage: 0, // Cambiado de barkDamage
+    soil_lifting: 0, // Cambiado de soilLifting
+    cut_damaged_roots: 0, // Cambiado de cutRoots
+    basal_rot: 0, // Cambiado de basalRot
+    exposed_surface_roots: 0, // Cambiado de exposedRoots
     wind: 0,
     drought: 0,
     status: 0,
@@ -265,18 +265,18 @@ export default function EditEva() {
       const formattedDate = format(birthDate, 'yyyy-MM-dd');
 
       const status =
-        Number(values.unbalancedCrown) +
-        Number(values.overextendedBranches) +
+        Number(values.unbalanced_crown) +
+        Number(values.overextended_branches) +
         Number(values.cracks) +
-        Number(values.deadBranches) +
+        Number(values.dead_branches) +
         Number(values.inclination) +
-        Number(values.VForks) +
+        Number(values.V_forks) +
         Number(values.cavities) +
-        Number(values.barkDamage) +
-        Number(values.soilLifting) +
-        Number(values.cutRoots) +
-        Number(values.basalRot) +
-        Number(values.exposedRoots);
+        Number(values.bark_damage) +
+        Number(values.soil_lifting) +
+        Number(values.cut_damaged_roots) +
+        Number(values.basal_rot) +
+        Number(values.exposed_surface_roots);
 
       const updatedValues = {
         ...values,

--- a/resources/ts/pages/Admin/Eva/Edit.tsx
+++ b/resources/ts/pages/Admin/Eva/Edit.tsx
@@ -135,18 +135,18 @@ export default function EditEva() {
     root_surface_diameter: 0,
     effective_root_area: 0,
     height_estimation: 0,
-    unbalanced_crown: 0, // Cambiado de unbalancedCrown
-    overextended_branches: 0, // Cambiado de overextendedBranches
+    unbalanced_crown: 0,
+    overextended_branches: 0,
     cracks: 0,
-    dead_branches: 0, // Cambiado de deadBranches
+    dead_branches: 0,
     inclination: 0,
-    V_forks: 0, // Cambiado de VForks
+    V_forks: 0,
     cavities: 0,
-    bark_damage: 0, // Cambiado de barkDamage
-    soil_lifting: 0, // Cambiado de soilLifting
-    cut_damaged_roots: 0, // Cambiado de cutRoots
-    basal_rot: 0, // Cambiado de basalRot
-    exposed_surface_roots: 0, // Cambiado de exposedRoots
+    bark_damage: 0,
+    soil_lifting: 0,
+    cut_damaged_roots: 0,
+    basal_rot: 0,
+    exposed_surface_roots: 0,
     wind: 0,
     drought: 0,
     status: 0,
@@ -284,7 +284,6 @@ export default function EditEva() {
         status: status,
       };
 
-      // Ensure all required fields are included and properly formatted
       const payload = {
         ...updatedValues,
         element_id: Number(updatedValues.element_id),

--- a/resources/ts/pages/Admin/Eva/Eva.tsx
+++ b/resources/ts/pages/Admin/Eva/Eva.tsx
@@ -254,9 +254,7 @@ export default function Evas() {
           className="p-datatable-sm">
           <Column
             header={t('admin.pages.evas.columns.name')}
-            body={(rowData: Eva) => (
-              <span>{rowData.element?.element_type?.name || 'N/A'}</span>
-            )}
+            body={(rowData: Eva) => <span>{rowData.element_id || 'N/A'}</span>}
           />
           <Column
             header={t('admin.pages.evas.columns.coordinates')}

--- a/resources/ts/pages/Admin/Eva/Show.tsx
+++ b/resources/ts/pages/Admin/Eva/Show.tsx
@@ -5,33 +5,7 @@ import { Card } from 'primereact/card';
 import { Button } from 'primereact/button';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '@iconify/react';
-
-interface Eva {
-  element_id: number;
-  date_birth: string;
-  height: number;
-  diameter: number;
-  crown_width: number;
-  crown_projection_area: number;
-  root_surface_diameter: number;
-  effective_root_area: number;
-  height_estimation: number;
-  unbalanced_crown: number;
-  overextended_branches: number;
-  cracks: number;
-  dead_branches: number;
-  inclination: number;
-  V_forks: number;
-  cavities: number;
-  bark_damage: number;
-  soil_lifting: number;
-  cut_damaged_roots: number;
-  basal_rot: number;
-  exposed_surface_roots: number;
-  wind: number;
-  drought: number;
-  status: number;
-}
+import { useTreeEvaluation, Eva } from '@/components/FuncionesEva';
 
 export default function ShowEva() {
   const { id } = useParams<{ id: string }>();
@@ -39,6 +13,16 @@ export default function ShowEva() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(true);
+
+  // Usamos el hook de evaluación de árboles
+  const {
+    getStatusMessage,
+    calculateStabilityIndex,
+    calculateGravityHeightRatio,
+    calculateRootCrownRatio,
+    calculateWindStabilityIndex,
+    getSeverityMessage,
+  } = useTreeEvaluation();
 
   useEffect(() => {
     const fetchEva = async () => {
@@ -55,174 +39,6 @@ export default function ShowEva() {
     fetchEva();
   }, [id]);
 
-  const getStatusMessage = (status: number) => {
-    const percentage = (status / 36) * 100;
-    if (percentage == 0 && percentage <= 24) {
-      return { message: t('admin.pages.evas.status.low'), color: '#6AA84F' };
-    }
-    if (percentage >= 25 && percentage <= 49) {
-      return {
-        message: t('admin.pages.evas.status.moderate'),
-        color: '#00FF00',
-      };
-    }
-    if (percentage >= 50 && percentage <= 74) {
-      return { message: t('admin.pages.evas.status.high'), color: '#FFFF00' };
-    }
-    if (percentage >= 75 && percentage <= 100) {
-      return {
-        message: t('admin.pages.evas.status.critical'),
-        color: '#FF0000',
-      };
-    }
-    return { message: t('admin.pages.evas.status.pending'), color: 'gray' };
-  };
-
-  const calculateStabilityIndex = (height: number, diameter: number) => {
-    const index = (height / diameter) * 100;
-    if (index < 50) {
-      return {
-        message: t('admin.pages.evas.stability.stable'),
-        color: '#6AA84F',
-      };
-    } else if (index >= 50 && index <= 80) {
-      return {
-        message: t('admin.pages.evas.stability.moderate'),
-        color: '#00FF00',
-      };
-    } else if (index > 80) {
-      return {
-        message: t('admin.pages.evas.stability.highRisk'),
-        color: '#FF0000',
-      };
-    } else {
-      return {
-        message: t('admin.pages.evas.stability.pending'),
-        color: 'gray',
-      };
-    }
-  };
-
-  const calculateGravityHeightRatio = (
-    heightEstimation: number,
-    height: number,
-  ) => {
-    const ratio = heightEstimation / height;
-    if (ratio < 0.3) {
-      return {
-        message: t('admin.pages.evas.gravityHeight.veryStable'),
-        color: '#6AA84F',
-      };
-    } else if (ratio >= 0.3 && ratio <= 0.5) {
-      return {
-        message: t('admin.pages.evas.gravityHeight.moderateRisk'),
-        color: '#00FF00',
-      };
-    } else if (ratio > 0.5) {
-      return {
-        message: t('admin.pages.evas.gravityHeight.highRisk'),
-        color: '#FF0000',
-      };
-    } else {
-      return {
-        message: t('admin.pages.evas.gravityHeight.pending'),
-        color: 'gray',
-      };
-    }
-  };
-
-  const calculateRootCrownRatio = (
-    effective_root_area: number,
-    crown_projection_area: number,
-  ) => {
-    const ratio = effective_root_area / crown_projection_area;
-    if (ratio > 2) {
-      return {
-        message: t('admin.pages.evas.rootCrown.veryStable'),
-        color: '#6AA84F',
-      };
-    } else if (ratio > 1.5 && ratio <= 2) {
-      return {
-        message: t('admin.pages.evas.rootCrown.stable'),
-        color: '#00FF00',
-      };
-    } else if (ratio > 1 && ratio <= 1.5) {
-      return {
-        message: t('admin.pages.evas.rootCrown.moderateStability'),
-        color: '#FFFF00',
-      };
-    } else if (ratio <= 1) {
-      return {
-        message: t('admin.pages.evas.rootCrown.highRisk'),
-        color: '#FF0000',
-      };
-    } else {
-      return {
-        message: t('admin.pages.evas.rootCrown.pending'),
-        color: 'gray',
-      };
-    }
-  };
-
-  const calculateWindStabilityIndex = (
-    height: number,
-    wind: number,
-    rootSurfaceDiameter: number,
-  ) => {
-    const index = (height * wind) / rootSurfaceDiameter;
-    if (index < 0.5) {
-      return {
-        message: t('admin.pages.evas.windStability.veryStable'),
-        color: '#6AA84F',
-      };
-    } else if (index >= 0.5 && index <= 1) {
-      return {
-        message: t('admin.pages.evas.windStability.moderateStability'),
-        color: '#FFFF00',
-      };
-    } else if (index > 1) {
-      return {
-        message: t('admin.pages.evas.windStability.highRisk'),
-        color: '#FF0000',
-      };
-    } else {
-      return {
-        message: t('admin.pages.evas.windStability.pending'),
-        color: 'gray',
-      };
-    }
-  };
-
-  const getSeverityMessage = (value: number) => {
-    switch (value) {
-      case 0:
-        return {
-          message: t('admin.pages.evas.severity.low'),
-          color: '#6AA84F',
-        };
-      case 1:
-        return {
-          message: t('admin.pages.evas.severity.moderate'),
-          color: '#00FF00',
-        };
-      case 2:
-        return {
-          message: t('admin.pages.evas.severity.high'),
-          color: '#FFFF00',
-        };
-      case 3:
-        return {
-          message: t('admin.pages.evas.severity.extreme'),
-          color: '#FF0000',
-        };
-      default:
-        return {
-          message: t('admin.pages.evas.severity.pending'),
-          color: 'gray',
-        };
-    }
-  };
-
   if (isLoading) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen">
@@ -238,6 +54,7 @@ export default function ShowEva() {
   if (!eva) {
     return <p>{t('not_found')}</p>;
   }
+
   const { message, color } = getStatusMessage(eva.status);
   const stabilityIndex = calculateStabilityIndex(eva.height, eva.diameter);
   const gravityHeightRatio = calculateGravityHeightRatio(

--- a/resources/ts/pages/Admin/Eva/Show.tsx
+++ b/resources/ts/pages/Admin/Eva/Show.tsx
@@ -14,7 +14,6 @@ export default function ShowEva() {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(true);
 
-  // Usamos el hook de evaluación de árboles
   const {
     getStatusMessage,
     calculateStabilityIndex,


### PR DESCRIPTION
This pull request includes changes to the `CreateEva` and `EditEva` components in the `resources/ts/pages/Admin/Eva` directory. The primary focus is on standardizing the naming conventions for various properties related to tree evaluation.

Changes to property names:

* [`resources/ts/pages/Admin/Eva/Create.tsx`](diffhunk://#diff-b30b98d2dc1faf654fe890519fc7dae76bfbd20404d1fb29ea0f4e3ccada5557R213-R221): Added new properties with standardized names (`unbalanced_crown`, `overextended_branches`, `dead_branches`, `V_forks`, `bark_damage`, `soil_lifting`, `cut_damaged_roots`, `basal_rot`, `exposed_surface_roots`).
* [`resources/ts/pages/Admin/Eva/Edit.tsx`](diffhunk://#diff-ca051ea54ec3a20d11aa184cc27b37287f67aae0090f7cf49f6582b267702cfbL138-R149): Updated initial state and status calculation to use standardized property names (`unbalanced_crown`, `overextended_branches`, `dead_branches`, `V_forks`, `bark_damage`, `soil_lifting`, `cut_damaged_roots`, `basal_rot`, `exposed_surface_roots`). [[1]](diffhunk://#diff-ca051ea54ec3a20d11aa184cc27b37287f67aae0090f7cf49f6582b267702cfbL138-R149) [[2]](diffhunk://#diff-ca051ea54ec3a20d11aa184cc27b37287f67aae0090f7cf49f6582b267702cfbL268-R279)