### PR TITLE
fix: update translation key for icon labels in CreateElementType comp…

### DIFF
--- a/resources/ts/pages/Admin/Settings/Element Types/Create.tsx
+++ b/resources/ts/pages/Admin/Settings/Element Types/Create.tsx
@@ -205,7 +205,9 @@ export default function CreateElementType() {
                               icon={'mdi:' + option}
                               className="mr-2 text-2xl"
                             />
-                            <span>{t('admin.icons.' + option)}</span>
+                            <span>
+                              {t('admin.pages.elementTypes.icons.' + option)}
+                            </span>
                           </div>
                         ) : null
                       }


### PR DESCRIPTION
This pull request includes a change to the `Create.tsx` file in the `resources/ts/pages/Admin/Settings/Element Types` directory. The change modifies the translation key used for displaying icon names to provide more specific context.

* [`resources/ts/pages/Admin/Settings/Element Types/Create.tsx`](diffhunk://#diff-9a78fa81a439611f3f359b1e500c8a76bfb4996585c7ae694ee191663786992bL208-R210): Updated the translation key from `admin.icons.` to `admin.pages.elementTypes.icons.` to provide a more specific context for icon names.…onent