### PR TITLE
Add getCenterZoom endpoint and integrate with map services

### DIFF
--- a/resources/ts/api/service/mapService.ts
+++ b/resources/ts/api/service/mapService.ts
@@ -13,7 +13,8 @@ import { Element } from '@/types/Element';
 import { ElementType } from '@/types/ElementType';
 import { Point } from '@/types/Point';
 import { TreeTypes } from '@/types/TreeTypes';
-import { ZoneCenterCoord } from '@/types/Zone';
+import { Zone, ZoneCenterCoord } from '@/types/Zone';
+import { getZoneZoom } from './zoneService';
 
 const DEFAULT_CENTER: [number, number] = [-3.70379, 40.41678];
 
@@ -33,7 +34,7 @@ export class MapService {
       container,
       style: 'mapbox://styles/mapbox/standard-satellite',
       center: this.getCenter(),
-      zoom: 14,
+      zoom: 16,
     });
   }
 
@@ -308,9 +309,15 @@ export class MapService {
     return { lat: point.latitude, lng: point.longitude };
   }
 
-  public flyTo(coord: [number, number], zoom = 16): void {
-    this.map.flyTo({ center: coord, zoom, essential: true });
+  public async  flyTo(selectedZone: Zone) {
+    if (selectedZone.id === null) return;
+    const { zoom, center }: ZoneCenterCoord = await getZoneZoom(selectedZone.id!);
+    
+    if (center) {
+      this.map.flyTo({ center: [center[0], center[1]], zoom, essential: true });
+    }
   }
+
 
   public resizeMap(): void {
     this.map?.resize();

--- a/resources/ts/api/service/zoneService.ts
+++ b/resources/ts/api/service/zoneService.ts
@@ -30,3 +30,8 @@ export const getZoneCoords = async (): Promise<ZoneCenterCoord[]> => {
   const res = await axiosClient.get(`/admin/points/location-contract`);
   return res.data;
 }
+
+export const getZoneZoom = async (zoneId: number): Promise<ZoneCenterCoord> => {
+  const res = await axiosClient.get(`/admin/zones/${zoneId}/center-zoom`)
+  return res.data;
+}

--- a/resources/ts/components/Map.tsx
+++ b/resources/ts/components/Map.tsx
@@ -192,10 +192,8 @@ export const MapComponent: React.FC<MapProps> = ({
     const service = mapServiceRef.current;
     if (!service || !selectedZone || !points.length) return;
     
-    const firstPoint = points.find((p) => p.zone_id === selectedZone.id);
-    if (firstPoint?.longitude && firstPoint?.latitude) {
-      service.flyTo([firstPoint.longitude, firstPoint.latitude]);
-    }
+    service.flyTo(selectedZone);
+    
   }, [selectedZone, points]);
 
   useEffect(() => {

--- a/resources/ts/types/Zone.ts
+++ b/resources/ts/types/Zone.ts
@@ -15,5 +15,6 @@ export interface Zone {
 export interface ZoneCenterCoord {
     zone_id?: number;
     center?:  number[];
+    zoom?: number;
 }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,6 +91,8 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/evas/element/{elementId}', [EvaController::class, 'getByElementId']);
 
         Route::get('points/location-contract', [PointController::class, 'getLocationContractZones']);
+
+        Route::get('zones/{zone_id}/center-zoom', [ZoneController::class, 'getCenterZoom']);
     });
 
     /* Worker protected routes */


### PR DESCRIPTION
This commit introduces a new API endpoint to retrieve the center coordinates and zoom level for a specified zone. The MapService and MapComponent have been updated to utilize this new functionality, allowing for dynamic zoom adjustments based on zone delimiters. Additionally, the Zone model has been modified to include a zoom property.