### PR TITLE
fix: improve event subscription handling in MapComponent

### DIFF
--- a/resources/ts/components/Map.tsx
+++ b/resources/ts/components/Map.tsx
@@ -341,11 +341,11 @@ export const MapComponent: React.FC<MapProps> = ({
 
   // Handle event subscriptions
   useEffect(() => {
-    const service = mapServiceRef.current;
-    if (!service) return;
-    
     const subscription = eventSubject.subscribe({
       next: (data: ZoneEvent) => {
+        const service = mapServiceRef.current;
+        if (!service) return;
+        
         // Handle element updates
         if (data.updateElements) {
           try {
@@ -518,7 +518,9 @@ export const MapComponent: React.FC<MapProps> = ({
       onCreatingElementChange(false);
       setSelectedZoneForElement(null);
       setNewPointCoord(null);
-      if (service) service.disableSingleClick();
+      if (mapServiceRef.current) {
+        mapServiceRef.current.disableSingleClick();
+      }
     };
   }, [points, elements, zonesRedux, handleElementCreation, toggleZoneVisibility, updateElementVisibility, onCreatingElementChange, hiddenElementTypes, hiddenZones]);
 


### PR DESCRIPTION
This pull request includes changes to the `MapComponent` in the `resources/ts/components/Map.tsx` file, focusing on improving the handling of event subscriptions and ensuring proper usage of the `mapServiceRef` reference.

Improvements to event handling:

* Updated the subscription to `eventSubject` to ensure the `mapServiceRef` is correctly referenced when handling `ZoneEvent` updates.

Refactoring for clarity and safety:

* Modified the logic for disabling single click to use `mapServiceRef.current` directly, ensuring the reference is always checked before calling `disableSingleClick`.